### PR TITLE
reflect

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,14 @@
+6 April
+https://dev.to/anichidera/how-to-write-a-simple-test-for-your-nextjs-app-2k1j
+Stuck; 
+
+simple 
+--simple.js
+----simple.helios
+
+nft-minter
+--pages/:x
+
 2 April
 Monday reflection lands in this file.
 How do I bring Certification and DevX together?


### PR DESCRIPTION
compare repo structure: 
`nft-minter`
entrypoint is `npm run dev`, which runs `next dev`, which (link) runs `pages/index.js`

<details><summary>`simple`</summary>
<p>

[source](https://github.com/aleeusgr/potential-robot/blob/koral-ci/test/simple.test.js)

there is not a `package.json` file, but it compiles. but with [node](https://en.wikipedia.org/wiki/Node.js); node is a runtime.
`simple.helios` is read as a string.
The `const` declaration creates block-scoped constants, much like variables declared using the [let](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) keyword.
[helios.Program.new](https://www.hyperion-bt.org/helios-book/api/reference/program.html?highlight=program#program)
program.compile -> [uplc](https://www.hyperion-bt.org/helios-book/api/reference/uplcprogram.html)

https://github.com/aleeusgr/potential-robot/blob/3fa08443f8c966ce8f812a2321e5b5ea20603a80/test/simple.test.js#L15-L28
</p>
</details> 


<details><summary>next.js</summary>
<p>
what is the role of [npm](https://github.com/npm) in this? 
npm ~ cabal

[Next.js](https://en.wikipedia.org/wiki/Next.js) 
routing system, 
pages export components,
caching

![image](https://user-images.githubusercontent.com/36756030/230330519-db3cfaa1-e136-458e-b4e2-82c46b67317f.png)

https://www.youtube.com/watch?v=_w0Ikk4JY7U

</p>
</details> 


<details><summary>Docs</summary>
<p>
[tutorial](https://dev.to/anichidera/how-to-write-a-simple-test-for-your-nextjs-app-2k1j)

https://en.wikipedia.org/wiki/React_(software)

![image](https://user-images.githubusercontent.com/36756030/230328333-3a8dd9f7-7ed7-418a-be20-bb9266552c60.png)

</p>
</details> 
